### PR TITLE
Fix stray end tag validation errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
           <p>
             <del>Labor MP Ed Husic has raised stated he had been in formed that the Australian Signals Directorate has raised concerns around AWS and the Sydney data centre in question, and - a month earlier - the Department of Home Affairs has advised the Government to move their data out of there by September this year<sup><a href = "#ref-17">[17]</a></sup>.</del>
             <br />
-            The Digital Transformation Agency has come out on record to ITWire, stating <i>"No COVIDSafe information will be stored in Global Switch facilities"</i><sup><a href = "#ref-18">[18]</a></sup>.</del>
+            The Digital Transformation Agency has come out on record to ITWire, stating <i>"No COVIDSafe information will be stored in Global Switch facilities"</i><sup><a href = "#ref-18">[18]</a></sup>.
           </p>
           <p>
             Concerns have also been raised over Australian based providers being overlooked, despite having the relevant government accreditations to host such data, such as AUCloud, Macquarie Telecom, Sliced Tech and Vault<sup><a href = "#ref-15">[15]</a></sup>.
@@ -128,34 +128,34 @@
 
           <h4>References</h4>
           <ul>
-            <li><span id = "ref-1"><sup>[1]</sup> <a href = "https://www.abc.net.au/news/2018-05-31/privacy-precedent-what-can-the-government-reveal-about-us/9816700">Privacy decision sets worrying precedent for what the Government can reveal about us - ABC</a></a></span></li>
-            <li><span id = "ref-2"><sup>[2]</sup> <a href = "https://www.theguardian.com/australia-news/2020/mar/08/melbourne-professor-quits-after-health-department-pressures-her-over-data-breach">Melbourne professor quits after health department pressures her over data breach - The Guardian</a></a></span></li>
-            <li><span id = "ref-3"><sup>[3]</sup> <a href = "https://www.theguardian.com/technology/2020/feb/28/australian-government-officials-accused-of-cavalier-disregard-for-unauthorised-metadata-access">Australian government officials accused of 'cavalier disregard' for unauthorised metadata access - The Guardian</a></a></span></li>
-            <li><span id = "ref-4"><sup>[4]</sup> <a href = "https://www.itnews.com.au/news/govt-to-release-source-code-of-forthcoming-covid-trace-app-546884">Govt to release source code of forthcoming 'COVID trace' app - IT News</a></a></span></li>
-            <li><span id = "ref-5"><sup>[5]</sup> <a href = "https://www.abc.net.au/radio/programs/am/heath-minister-says-govt-will-release-covidsafe-source-code/12187634">Federal Heath minister says Govt will release COVIDSafe source code - ABC</a></a></span></li>
-            <li><span id = "ref-6"><sup>[6]</sup> <a href = "https://www.legislation.gov.au/Details/F2020L00480">Biosecurity (Human Biosecurity Emergency) (Human Coronavirus with Pandemic Potential) (Emergency Requirements—Public Health Contact Information) Determination 2020 - Federal Register of Legislation</a></a></span></li>
-            <li><span id = "ref-7"><sup>[7]</sup> <a href = "https://www.zdnet.com/article/covidsafe-privacy-report-calls-on-state-health-bodies-to-comply-with-privacy-act/">COVIDSafe privacy report calls on state health bodies to comply with Privacy Act - ZDNet</a></a></span></li>
-            <li><span id = "ref-8"><sup>[8]</sup> <a href = "https://www.lawcouncil.asn.au/media/media-releases/tracing-app-has-been-released-but-privacy-concerns-still-exist">Tracing app has been released but privacy concerns still exist - Law Council of Australia</a></a></span></li>
-            <li><span id = "ref-9"><sup>[9]</sup> <a href = "https://www.innovationaus.com/covidsafe-code-to-be-released-within-two-weeks/">COVIDSafe code to be released within two weeks - Innovation Aus</a></a></span></li>
-            <li><span id = "ref-10"><sup>[10]</sup> <a href = "https://www.afr.com/technology/five-eyes-fears-rise-over-aussie-encryption-laws-20190221-h1bj6f">Five Eyes fears rise over Aussie encryption laws - AFR</a></a></span></li>
-            <li><span id = "ref-11"><sup>[11]</sup> <a href = "https://junkee.com/encryption-bill-labor-vote/185652">Labor Spent This Week Criticising The Encryption Bill. Then They Voted For It Anyway. - Junkee</a></a></span></li>
-            <li><span id = "ref-12"><sup>[12]</sup> <a href = "https://www.smh.com.au/politics/federal/former-top-public-servant-i-won-t-download-the-coronavirus-app-20200427-p54nn9.html">Former top public servant: I won't download the coronavirus app - SMH</a></a></span></li>
-            <li><span id = "ref-13"><sup>[13]</sup> <a href = "https://www.health.gov.au/sites/default/files/documents/2020/04/covidsafe-application-privacy-impact-assessment-agency-response.pdf">Privacy Impact Assessment (PDF) - Department of Health</a></a></span></li>
-            <li><span id = "ref-14"><sup>[14]</sup> <a href = "https://www.smh.com.au/politics/federal/nothing-particularly-disturbing-coronavirus-app-safe-review-finds-20200420-p54lea.html">'Nothing particularly disturbing': Coronavirus app safe, review finds - SMH</a></a></span></li>
-            <li><span id = "ref-15"><sup>[15]</sup> <a href = "https://www.abc.net.au/news/2020-04-24/amazon-to-provide-cloud-services-for-coronavirus-tracing-app/12176682">Australia's coronavirus tracing app's data storage contract goes offshore to Amazon - ABC</a></a></span></li>
-            <li><span id = "ref-16"><sup>[16]</sup> <a href = "https://www.itnews.com.au/news/australia-us-negotiate-cloud-act-data-swap-pact-532005">Australia, US negotiate CLOUD Act data swap pact - IT News</a></a></span></li>
-            <li><span id = "ref-17"><sup>[17]</sup> <a href = "https://www.itwire.com/government-tech-policy/covidsafe-app-aws-using-chinese-owned-data-centre-in-sydney,-says-husic.html">COVIDSafe app: AWS using Chinese-owned data centre in Sydney, says Husic - IT Wire</a></a></span></li>
-            <li><span id = "ref-18"><sup>[18]</sup> <a href = "https://www.itwire.com/government-tech-policy/dta-says-aws-will-not-store-covidsafe-data-at-chinese-owned-data-centre.html">DTA says AWS will not store COVIDSafe data at Chinese-owned data centre - IT Wire</a></a></span></li>
-            <li><span id = "ref-19"><sup>[19]</sup> <a href = "https://docs.google.com/document/d/17GuApb1fG3Bn0_DVgDQgrtnd_QO3foBl7NVb8vaWeKc/edit#">Google Doc, contributed to by many developers - Geoffrey Huntley</a></a></span></li>
-            <li><span id = "ref-20"><sup>[20]</sup> <a href = "https://www.smartcompany.com.au/coronavirus/angry-mob-cannon-brookes-covidsafe-app/">‘Turn the angry-mob mode off’: Cannon-Brookes calls on divided tech industry to back government’s COVIDSafe app - SmartCompany</a></a></span></li>
+            <li><span id = "ref-1"><sup>[1]</sup> <a href = "https://www.abc.net.au/news/2018-05-31/privacy-precedent-what-can-the-government-reveal-about-us/9816700">Privacy decision sets worrying precedent for what the Government can reveal about us - ABC</a></span></li>
+            <li><span id = "ref-2"><sup>[2]</sup> <a href = "https://www.theguardian.com/australia-news/2020/mar/08/melbourne-professor-quits-after-health-department-pressures-her-over-data-breach">Melbourne professor quits after health department pressures her over data breach - The Guardian</a></span></li>
+            <li><span id = "ref-3"><sup>[3]</sup> <a href = "https://www.theguardian.com/technology/2020/feb/28/australian-government-officials-accused-of-cavalier-disregard-for-unauthorised-metadata-access">Australian government officials accused of 'cavalier disregard' for unauthorised metadata access - The Guardian</a></span></li>
+            <li><span id = "ref-4"><sup>[4]</sup> <a href = "https://www.itnews.com.au/news/govt-to-release-source-code-of-forthcoming-covid-trace-app-546884">Govt to release source code of forthcoming 'COVID trace' app - IT News</a></span></li>
+            <li><span id = "ref-5"><sup>[5]</sup> <a href = "https://www.abc.net.au/radio/programs/am/heath-minister-says-govt-will-release-covidsafe-source-code/12187634">Federal Heath minister says Govt will release COVIDSafe source code - ABC</a></span></li>
+            <li><span id = "ref-6"><sup>[6]</sup> <a href = "https://www.legislation.gov.au/Details/F2020L00480">Biosecurity (Human Biosecurity Emergency) (Human Coronavirus with Pandemic Potential) (Emergency Requirements—Public Health Contact Information) Determination 2020 - Federal Register of Legislation</a></span></li>
+            <li><span id = "ref-7"><sup>[7]</sup> <a href = "https://www.zdnet.com/article/covidsafe-privacy-report-calls-on-state-health-bodies-to-comply-with-privacy-act/">COVIDSafe privacy report calls on state health bodies to comply with Privacy Act - ZDNet</a></span></li>
+            <li><span id = "ref-8"><sup>[8]</sup> <a href = "https://www.lawcouncil.asn.au/media/media-releases/tracing-app-has-been-released-but-privacy-concerns-still-exist">Tracing app has been released but privacy concerns still exist - Law Council of Australia</a></span></li>
+            <li><span id = "ref-9"><sup>[9]</sup> <a href = "https://www.innovationaus.com/covidsafe-code-to-be-released-within-two-weeks/">COVIDSafe code to be released within two weeks - Innovation Aus</a></span></li>
+            <li><span id = "ref-10"><sup>[10]</sup> <a href = "https://www.afr.com/technology/five-eyes-fears-rise-over-aussie-encryption-laws-20190221-h1bj6f">Five Eyes fears rise over Aussie encryption laws - AFR</a></span></li>
+            <li><span id = "ref-11"><sup>[11]</sup> <a href = "https://junkee.com/encryption-bill-labor-vote/185652">Labor Spent This Week Criticising The Encryption Bill. Then They Voted For It Anyway. - Junkee</a></span></li>
+            <li><span id = "ref-12"><sup>[12]</sup> <a href = "https://www.smh.com.au/politics/federal/former-top-public-servant-i-won-t-download-the-coronavirus-app-20200427-p54nn9.html">Former top public servant: I won't download the coronavirus app - SMH</a></span></li>
+            <li><span id = "ref-13"><sup>[13]</sup> <a href = "https://www.health.gov.au/sites/default/files/documents/2020/04/covidsafe-application-privacy-impact-assessment-agency-response.pdf">Privacy Impact Assessment (PDF) - Department of Health</a></span></li>
+            <li><span id = "ref-14"><sup>[14]</sup> <a href = "https://www.smh.com.au/politics/federal/nothing-particularly-disturbing-coronavirus-app-safe-review-finds-20200420-p54lea.html">'Nothing particularly disturbing': Coronavirus app safe, review finds - SMH</a></span></li>
+            <li><span id = "ref-15"><sup>[15]</sup> <a href = "https://www.abc.net.au/news/2020-04-24/amazon-to-provide-cloud-services-for-coronavirus-tracing-app/12176682">Australia's coronavirus tracing app's data storage contract goes offshore to Amazon - ABC</a></span></li>
+            <li><span id = "ref-16"><sup>[16]</sup> <a href = "https://www.itnews.com.au/news/australia-us-negotiate-cloud-act-data-swap-pact-532005">Australia, US negotiate CLOUD Act data swap pact - IT News</a></span></li>
+            <li><span id = "ref-17"><sup>[17]</sup> <a href = "https://www.itwire.com/government-tech-policy/covidsafe-app-aws-using-chinese-owned-data-centre-in-sydney,-says-husic.html">COVIDSafe app: AWS using Chinese-owned data centre in Sydney, says Husic - IT Wire</a></span></li>
+            <li><span id = "ref-18"><sup>[18]</sup> <a href = "https://www.itwire.com/government-tech-policy/dta-says-aws-will-not-store-covidsafe-data-at-chinese-owned-data-centre.html">DTA says AWS will not store COVIDSafe data at Chinese-owned data centre - IT Wire</a></span></li>
+            <li><span id = "ref-19"><sup>[19]</sup> <a href = "https://docs.google.com/document/d/17GuApb1fG3Bn0_DVgDQgrtnd_QO3foBl7NVb8vaWeKc/edit#">Google Doc, contributed to by many developers - Geoffrey Huntley</a></span></li>
+            <li><span id = "ref-20"><sup>[20]</sup> <a href = "https://www.smartcompany.com.au/coronavirus/angry-mob-cannon-brookes-covidsafe-app/">‘Turn the angry-mob mode off’: Cannon-Brookes calls on divided tech industry to back government’s COVIDSafe app - SmartCompany</a></span></li>
       <!--
-            <li><span id = "ref-X"><sup>[X]</sup> <a href = "LINK">TITLE</a></a></span></li>
-            <li><span id = "ref-X"><sup>[X]</sup> <a href = "LINK">TITLE</a></a></span></li>
+            <li><span id = "ref-X"><sup>[X]</sup> <a href = "LINK">TITLE</a></span></li>
+            <li><span id = "ref-X"><sup>[X]</sup> <a href = "LINK">TITLE</a></span></li>
       -->
           </ul>
 
           <p>
-            <br/><small>Created by <a href = "https://github.com/whiteydude">Andrew White</a>, an Australian nerd who is concerned with the carte blanche approach to privacy that seems commonplace.</a>.</small>
+            <br/><small>Created by <a href = "https://github.com/whiteydude">Andrew White</a>, an Australian nerd who is concerned with the carte blanche approach to privacy that seems commonplace.</small>
           </p>
           <p>
             <small>Are there mistakes, or could there be improvements? Corrections and design changes are welcome. <a href = "https://github.com/WhiteyDude/iscovidsafesafe.com/pulls">Pull requests</a> are preferred, or just <a href = "https://github.com/WhiteyDude/iscovidsafesafe.com/issues">open an issue</a> if you're not technical!</small>


### PR DESCRIPTION
Remove a bunch of stray end tags so that index.html [validates](https://validator.w3.org/nu/?doc=https%3A%2F%2Fiscovidsafesafe.com%2F) without error. Need to scroll right to see them in the diff.

(There is still the warning about viewport, and I would suggest removing `maximum-scale=1.0`, but that is a separate issue.)